### PR TITLE
Fix rows affected logging for custom SQL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -159,6 +159,7 @@ Snowflake timestamp improvements. This release fixes breaks and provides enhance
 - (#6710) Handle changes skipped due to OS mismatch DAT-19334 @wwillard7800
 
 ### Bug Fixes
+- (#7043) Fix rows affected not shown for custom SQL DML statements @mvanvliet
 - (#6900) INT-185 - Solving the situation where the customer tries to connect t @CharlesQueiroz
 - (#6838) Upon Evaluation of changeLogPropertyDefinied precondition also include local properties of nested changesets. @2fxprogeeme
 - (#6875) Fix Oracle regression from splitStatements:false change DAT-19983 @wwillard7800

--- a/liquibase-standard/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
+++ b/liquibase-standard/src/main/java/liquibase/executor/jvm/JdbcExecutor.java
@@ -43,6 +43,9 @@ public class JdbcExecutor extends AbstractExecutor {
 
     public static final String SHOULD_UPDATE_ROWS_AFFECTED_SCOPE_KEY = "shouldUpdateRowsAffected";
     public static final String ROWS_AFFECTED_SCOPE_KEY = "rowsAffected";
+    private static final Pattern DML_PATTERN = Pattern.compile(
+            "^\\s*(?:SELECT\\b|INSERT\\b|UPDATE\\b|DELETE\\b|MERGE\\b).*",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     /**
      * Return the name of the Executor
@@ -479,8 +482,10 @@ public class JdbcExecutor extends AbstractExecutor {
         }
 
         private boolean isDML(String statement) {
-            Pattern dmlPattern = Pattern.compile("^\\s*?(SELECT\\s|INSERT\\s|UPDATE\\s|DELETE\\s|MERGE\\s)(.*)");
-            Matcher m = dmlPattern.matcher(statement);
+            if (statement == null) {
+                return false;
+            }
+            Matcher m = DML_PATTERN.matcher(statement);
             return m.matches();
         }
 

--- a/liquibase-standard/src/test/java/liquibase/executor/jvm/JdbcExecutorTest.java
+++ b/liquibase-standard/src/test/java/liquibase/executor/jvm/JdbcExecutorTest.java
@@ -58,4 +58,17 @@ public class JdbcExecutorTest {
         assertEquals("(0) ", new JdbcExecutor().getErrorCode(new SQLException()));
     }
 
+    @Test
+    public void isDmlShouldBeCaseInsensitive() throws Exception {
+        JdbcExecutor executor = new JdbcExecutor();
+        Class<?> clazz = Class.forName("liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback");
+        java.lang.reflect.Constructor<?> ctor = clazz.getDeclaredConstructor(JdbcExecutor.class, liquibase.statement.SqlStatement.class, java.util.List.class);
+        ctor.setAccessible(true);
+        Object callback = ctor.newInstance(executor, null, java.util.Collections.emptyList());
+        java.lang.reflect.Method method = clazz.getDeclaredMethod("isDML", String.class);
+        method.setAccessible(true);
+        boolean result = (Boolean) method.invoke(callback, "insert into t values (1)");
+        assertTrue(result);
+    }
+
 }


### PR DESCRIPTION
## Summary
- honor custom SQL with case-insensitive DML detection
- ensure `isDML` matches custom statements
- test lowercase DML detection
- document the fix in changelog under Bug Fixes

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_685da160a8ec8328a55ad22ab8a4970d